### PR TITLE
Adding the possibility to specify a custom mac address

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -18,6 +18,8 @@
     user_data_file: cloud-init-d/ud-docker.yaml
     ubuntu_version: 22.04
     ssh_public_key_file: ~/.ssh/id_rsa.pub
+    # optional
+    # mac_address: AA:BB:CC:DD:EE:FF
   vars_files:
     - group_vars/metadata.yaml
   tasks:

--- a/templates/govc.sh.j2
+++ b/templates/govc.sh.j2
@@ -10,6 +10,12 @@ govc vm.change -vm {{ vmname }} \
    -e disk.enableUUID=1 \
    -m {{ mem }} \
    -c {{ cpu }}
+{% if (mac_address is defined) %}
+govc vm.network.change -vm {{ vmname }} \
+   -net.address={{ mac_address }} \
+   -vm {{ vmname }} \
+   ethernet-0
+{% endif %}
 {% if (data_disks is defined) and (data_disks is not none) %}
 {% for disk in data_disks %}
 govc vm.disk.create -vm {{ vmname }} -name {{ vmname }}/{{ disk }} -size {{ data_disks[disk] }} -thick -ds {{ ds }}


### PR DESCRIPTION
I modified your Ansible playbook to optionally allow the creation of a VM with a custom MAC address. Might be useful when provisioning VM's on a DC with DHCP enabled.